### PR TITLE
获取model的类名称时,使用rtrim可能造成字符的误清除

### DIFF
--- a/fastphp/Model.class.php
+++ b/fastphp/Model.class.php
@@ -13,7 +13,8 @@ class Model extends Sql {
         
         // 获取对象所属类的名称
         $this->_model = get_class($this);
-        $this->_model = rtrim($this->_model, 'Model');
+        //$this->_model = rtrim($this->_model, 'Model');
+        $this->_model = substr($this->_model, 0, -5);
         
         // 数据库表名与类名一致
         $this->_table = strtolower($this->_model);


### PR DESCRIPTION
$this->_model = rtrim($this->_model, 'Model');
使用rtrim()函数可能造成$this->_model尾部,包含'Model'字符串任何一个字符被清除.建议使用substr()
